### PR TITLE
Fix: nft update, options must specified before command.

### DIFF
--- a/luci-app-nft-qos/luasrc/controller/nft-qos.lua
+++ b/luci-app-nft-qos/luasrc/controller/nft-qos.lua
@@ -29,7 +29,7 @@ end
 function action_rate()
 	luci.http.prepare_content("application/json")
 
-	local bwc = io.popen("nft list ruleset -j 2>/dev/null")
+	local bwc = io.popen("nft -j list ruleset 2>/dev/null")
 	if bwc then
 
 		while true do

--- a/package/files/lib/monitor.sh
+++ b/package/files/lib/monitor.sh
@@ -6,7 +6,7 @@
 . /lib/nft-qos/core.sh
 
 qosdef_monitor_get_ip_handle() { # <family> <chain> <ip>
-	echo $(nft list chain $1 nft-qos-monitor $2 -a 2>/dev/null | grep $3 | awk '{print $11}')
+	echo $(nft -a list chain $1 nft-qos-monitor $2 2>/dev/null | grep $3 | awk '{print $11}')
 }
 
 qosdef_monitor_add() { # <mac> <ip> <hostname>


### PR DESCRIPTION
Hi,
According to this [commit](http://git.netfilter.org/nftables/commit/?id=fb9cea50e8b370b6931e7b53b1a881d3b95b1c91) in nftables, arguments must be specified before commands.
It will caused several problem in openwrt 21, this commit should fix it. 